### PR TITLE
fix: fix that when the gravatar changes from A to B, the default value of the input form will remain as A

### DIFF
--- a/src/pages/UserSettings/Account/AvatarUpload.tsx
+++ b/src/pages/UserSettings/Account/AvatarUpload.tsx
@@ -59,7 +59,9 @@ const AvatarUpload: React.FC = () => {
   const initModal = () => {
     setModalVisible(true);
     setPreview(initialState?.user?.gravatar ?? '');
-    form.resetFields();
+    form.setFields([
+      { name: 'gravatar', value: initialState?.user?.gravatar ?? '' },
+    ]);
   };
 
   const submitPatch = async () => {


### PR DESCRIPTION
default value of the input form should be the current user's gravatar (which should be B after the change)